### PR TITLE
#42 fixed: obBackPressed not fired when back key pressed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ A demo-app can be installed from [Play Store](https://play.google.com/store/apps
 ### v1.1.x patches on `master`
 
 - no WRITE_EXTERNAL_STORAGE requests if not `enableOptions(true)`;
+
 - after requested permissions, try showing dialog again instead of return directly;
+
+- #42: onBackPressedListener not fired.
+
+  Now, use `withCancelListener` to handle back key. see also [below](#onCancelListener)
 
 ### v1.1.x
 
@@ -104,7 +109,8 @@ FileChooser android library give a simple file/folder chooser in single call:
 ```java
     new ChooserDialog().with(this)
             .withFilter(true, false)
-            .withStartFile(startingDir)
+        	.withStartFile(startingDir)
+        	// to handle the result(s)
             .withChosenListener(new ChooserDialog.Result() {
                 @Override
                 public void onChoosePath(String path, File pathFile) {
@@ -126,6 +132,13 @@ FileChooser android library give a simple file/folder chooser in single call:
                     Toast.makeText(MainActivity.this, "FILE: " + path, Toast.LENGTH_SHORT).show();
                 }
             })
+        	// to handle the back key pressed or clicked outside the dialog:
+        	.withOnCancelListener(new DialogInterface.OnCancelListener() {
+    			public void onCancel(DialogInterface dialog) {
+			        Log.d("CANCEL", "CANCEL");
+			        dialog.cancel(); // MUST have
+    			}
+			})
             .build()
             .show();
 
@@ -210,11 +223,32 @@ Since 1.1.6, 2 new options are available:
 
 1.1.7 or Higher, try `withNegativeButton()` and `withNegativeButtonListener()` **instead of `withOnBackPressedListener()`.**
 
+---
+
 #### withOnBackPressedListener
 
 **deprecated.**
 
-~~But, `Escape` key may trigger it.~~
+
+
+#### onCancelListener
+
+`onCancelListener` will be triggered on back pressed or clicked outside of dialog.
+
+You **MUST** invoke `dialog.cancel()` while override the default `onCancelListener` :
+
+```java
+.withOnCancelListener(new DialogInterface.OnCancelListener() {
+    public void onCancel(DialogInterface dialog) {
+        Log.d("CANCEL", "CANCEL");
+        dialog.cancel(); // MUST have
+    }
+})
+```
+
+
+
+---
 
 #### New calling chain
 

--- a/app/src/main/java/com/obsez/android/lib/filechooser/demo/ChooseFileActivityFragment.java
+++ b/app/src/main/java/com/obsez/android/lib/filechooser/demo/ChooseFileActivityFragment.java
@@ -90,6 +90,7 @@ public class ChooseFileActivityFragment extends Fragment implements View.OnClick
                         @Override
                         public void onCancel(DialogInterface dialog) {
                             Log.d("CANCEL", "CANCEL");
+                            dialog.cancel();
                         }
                     })
                     .withNegativeButtonListener(new DialogInterface.OnClickListener() {
@@ -115,13 +116,13 @@ public class ChooseFileActivityFragment extends Fragment implements View.OnClick
                         }
                     })
                     .enableOptions(true)
-                    .withOnBackPressedListener(new ChooserDialog.OnBackPressedListener() {
-                        @Override
-                        public void onBackPressed(AlertDialog dialog) {
-                            Log.d("backpressed", "back pressed");
-                            dialog.dismiss();
-                        }
-                    })
+                    //.withOnBackPressedListener(new ChooserDialog.OnBackPressedListener() {
+                    //    @Override
+                    //    public void onBackPressed(AlertDialog dialog) {
+                    //        Log.d("backpressed", "back pressed");
+                    //        dialog.dismiss();
+                    //    }
+                    //})
                     .build()
                     .show();
             }

--- a/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
+++ b/library/src/main/java/com/obsez/android/lib/filechooser/ChooserDialog.java
@@ -287,9 +287,8 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
     }
 
     /**
-     * it's NOT recommended to use the `withOnCancelListener`, replace with `withNegativeButtonListener` pls.
+     * onCancelListener will be triggered on back pressed or clicked outside of dialog
      *
-     * @deprecated will be removed at v1.2
      */
     public ChooserDialog withOnCancelListener(final DialogInterface.OnCancelListener listener) {
         this._cancelListener2 = listener;
@@ -413,6 +412,14 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
 
         if (_cancelListener2 != null) {
             builder.setOnCancelListener(_cancelListener2);
+        } else {
+            builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
+                @Override
+                public void onCancel(DialogInterface dialog) {
+                    Log.v("Cancel", "Cancel");
+                    dialog.cancel();
+                }
+            });
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && _onDismissListener != null) {
@@ -423,7 +430,7 @@ public class ChooserDialog implements AdapterView.OnItemClickListener, DialogInt
             @Override
             public boolean onKey(final DialogInterface dialog, final int keyCode, final KeyEvent event) {
                 switch (keyCode) {
-                    case KeyEvent.KEYCODE_BACK:
+                    //case KeyEvent.KEYCODE_BACK:
                     case KeyEvent.KEYCODE_ESCAPE:
                         if (event.getAction() == KeyEvent.ACTION_UP) {
                             if (_newFolderView != null && _newFolderView.getVisibility() == View.VISIBLE) {


### PR DESCRIPTION
i had have a better way to handle the back key:

1. Do not use `onBackListener()`, it's really deprecated;
2. import _new new_ patch and handle `onCancelListener`
   ```java
   .withOnCancelListener(new DialogInterface.OnCancelListener() {
       public void onCancel(DialogInterface dialog) {
           Log.d("CANCEL", "CANCEL");
           dialog.cancel(); // MUST have
       }
   })
   ```

It's better than last patch, because `onCancel` can handle back key or clicked outside the dialog.